### PR TITLE
gwdetchar-overflow: workaround missing frame at GPS start

### DIFF
--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -157,8 +157,12 @@ for dcuid in args.dcuid:
     channel = overflow.ligo_accum_overflow_channel(dcuid, args.ifo)
     if args.deep:
         gprint("    Getting list of overflow channels...", end=' ')
-        channels = overflow.ligo_model_overflow_channels(
-            dcuid, args.ifo, args.frametype, gpstime=span[0])
+        try:
+            channels = overflow.ligo_model_overflow_channels(
+                dcuid, args.ifo, args.frametype, gpstime=span[0])
+        except IndexError:  # no frame found for GPS start, try GPS end
+            channels = overflow.ligo_model_overflow_channels(
+                dcuid, args.ifo, args.frametype, gpstime=span[-1])
         gprint("    %d channels found" % len(channel))
     for seg in cachesegs:
         c = cache.sieve(segment=seg)


### PR DESCRIPTION
if no frame found at GPS start, finding the list of overflow channels will raise an `IndexError`, so just try and use GPS end as a backup
